### PR TITLE
multimap would not compile in ruby 2.2

### DIFF
--- a/ext/nested_multimap_ext.c
+++ b/ext/nested_multimap_ext.c
@@ -1,4 +1,7 @@
 #include "ruby.h"
+#ifndef RHASH_IFNONE
+#define HASH_IFNONE (RHASH(h)->ifnone)
+#endif
 
 VALUE cNestedMultimap;
 
@@ -10,7 +13,7 @@ static VALUE rb_nested_multimap_aref(int argc, VALUE *argv, VALUE self)
 	for (i = 0, r = self; rb_obj_is_kind_of(r, cNestedMultimap) == Qtrue; i++) {
 		h = rb_funcall(r, rb_intern("_internal_hash"), 0);
 		Check_Type(h, T_HASH);
-		r = (i < argc) ? rb_hash_aref(h, argv[i]) : RHASH(h)->ifnone;
+		r = (i < argc) ? rb_hash_aref(h, argv[i]) : RHASH_IFNONE(h);
 	}
 
 	return r;


### PR DESCRIPTION
Per https://github.com/ruby/ruby/commit/8250aa2df0d6b4dcfa11dbad5307d28c2d5dd85f, RHASH is no longer provided by ruby.h.  Looks like multimap just needed an RHASH_IFNONE check anyways, so I've replaced it with that macro, which is available, and defined it to what it was prior to ruby 2.2 if it is not available.

Note that RHASH_IFNONE is deprecated, so this is just kicking the can down the road a bit.

I'm sending this to you as rubygems lists your repo as the gem homepage.