### PR TITLE
Multiset is broken with ruby 2.3

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require 'rubygems/specification'
 spec = eval(File.read('multimap.gemspec'))
 
 if spec.has_rdoc
-  require 'rake/rdoctask'
+  require 'rdoc/task'
 
   Rake::RDocTask.new { |rdoc|
     rdoc.options = spec.rdoc_options

--- a/lib/multiset.rb
+++ b/lib/multiset.rb
@@ -17,6 +17,10 @@ class Multiset < Set
     super
   end
 
+  def include?(e)
+    @hash.include?(e)
+  end
+
   # Returns the number of times an element belongs to the multiset.
   def multiplicity(e)
     @hash[e]

--- a/multimap.gemspec
+++ b/multimap.gemspec
@@ -24,4 +24,6 @@ Gem::Specification.new do |s|
   s.email    = 'josh@joshpeek.com'
   s.homepage = 'http://github.com/doxavore/multimap'
   s.license  = 'MIT'
+
+  s.add_development_dependency 'rspec', '< 2.0'
 end


### PR DESCRIPTION
`Multiset` depends on `Set` and the implementation of `Set#include?` has changed: 
- ruby 2.2: `@hash.include?(e)`
- ruby 2.3: `@hash[e]`

This change overrides `#include?` to use the ruby 2.2 and earlier implementation that `Multiset` relies on.

Also, replace the obsolete `require 'rake/rdoctask'` and a version restriction for rspec as the tests are incompatible with newer releases.